### PR TITLE
refactor: user is always just a string

### DIFF
--- a/src/data-access/FetchUserRepository.ts
+++ b/src/data-access/FetchUserRepository.ts
@@ -9,9 +9,9 @@ export default class FetchUserRepository implements UserRepository {
 				return null;
 			}
 			console.log( { user } );
-			return user as User; // Todo: verify that this is the structure that we have here
+			return user.displayName as User;
 		} catch ( e ) {
-			console.log(e); // not json
+			console.log(e);
 			// TODO show better error depending on error
 			return null;
 		}

--- a/src/data-access/UserRepository.ts
+++ b/src/data-access/UserRepository.ts
@@ -2,8 +2,4 @@ export default interface UserRepository {
 	getCurrentUser(): Promise<null | User>;
 }
 
-export interface User {
-	displayName: string;
-	userName: string;
-	// TODO: add babel?
-}
+export type User = string;

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -2,11 +2,10 @@ import { RootState } from '@/store/index';
 
 export default {
 	userDisplayName( rootState: RootState ): null | string {
-		console.log( { rootStateUser: rootState.user } );
 		if ( rootState.user === null ) {
 			return null;
 		}
 
-		return rootState.user.displayName;
+		return rootState.user;
 	},
 };


### PR DESCRIPTION
After trying it out on toolforge, we discovered that the displayName _is_ the username so we can simplify our data structure a bit.

@itamargiv Feel free to merge this whenever you need a pull request to merge to test the deploy functionality :)