### PR TITLE
fix: logout should only ever happen on post

### DIFF
--- a/server.js
+++ b/server.js
@@ -97,13 +97,13 @@ router.get( "/auth/mediawiki/callback", function( req, res, next ) {
 	} )( req, res, next );
 } );
 
-router.get( "/logout" , function ( req, res ) {
+router.post( "/logout" , function ( req, res ) {
 	delete req.session.user;
 	res.redirect( req.baseUrl + "/" );
 } );
 
 router.get( '/currentUser', function ( req, res ) {
-	// return res.status( 200 ).send( JSON.stringify( { displayName: 'TestUser (WMF)', username: 'testuser' } ) );
+	// return res.status( 200 ).send( JSON.stringify( { displayName: 'TestUser (WMF)' } ) );
 	const user  = req && req.session && req.session.user;
 	if (!user) {
 		return res.status(401).send(false);

--- a/src/components/CreatingSensesApp.vue
+++ b/src/components/CreatingSensesApp.vue
@@ -1,6 +1,9 @@
 <template>
 	<div>
-		<nav v-if="userDisplayName !== null"><mark>TODO NEXT</mark> {{userDisplayName}}</nav>
+		<UserTools
+			v-if="userDisplayName !== null"
+			:user-display-name="userDisplayName"
+		/>
 		<main>
 		<h1>Connecting Senses Tool</h1>
 		<p>
@@ -17,9 +20,10 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import Login from '@/components/Login.vue';
+import UserTools from '@/components/UserTools.vue';
 
 export default defineComponent( {
-	components: { Login },
+	components: { UserTools, Login },
 	computed: {
 		userDisplayName(): null | string {
 			return this.$store.getters.userDisplayName;

--- a/src/components/UserTools.vue
+++ b/src/components/UserTools.vue
@@ -1,0 +1,27 @@
+<template>
+	<nav class="cs-user-tools">
+		You're logged in as <b>{{ userDisplayName }}</b>
+		<form class="cs-user-tools__logout-form" method="post" action="/logout">
+			<button type="submit">log out</button>
+		</form>
+	</nav>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent( {
+	props: {
+		userDisplayName: {
+			type: String,
+			required: true,
+		},
+	},
+} );
+</script>
+
+<style lang="scss">
+.cs-user-tools__logout-form {
+	display: inline;
+}
+</style>

--- a/src/data-access/FetchUserRepository.ts
+++ b/src/data-access/FetchUserRepository.ts
@@ -8,7 +8,6 @@ export default class FetchUserRepository implements UserRepository {
 			if (!user) {
 				return null;
 			}
-			console.log( { user } );
 			return user.displayName as User;
 		} catch ( e ) {
 			console.log(e);


### PR DESCRIPTION
A get request should never change server state.

This adds a visual change and allows logout.

I can explain it for review purposes, but it can also be merged straight away if that is more convenient to test something.