### PR TITLE
fix: quadrupal search suggestions

### DIFF
--- a/src/components/ItemSearch.vue
+++ b/src/components/ItemSearch.vue
@@ -42,7 +42,7 @@ export default defineComponent( {
 				'searchItemValues',
 				{
 					search: event.query,
-					limit: 12,
+					limit: 48,
 					languageCode: this.languageCode,
 				},
 			);

--- a/src/components/LanguagePicker.vue
+++ b/src/components/LanguagePicker.vue
@@ -67,7 +67,7 @@ export default defineComponent( {
 				'searchItemValues',
 				{
 					search: event.query,
-					limit: 12,
+					limit: 48,
 				},
 			);
 		},


### PR DESCRIPTION
Since we can't load more suggestions on scroll, we have to load a bigger number of suggestions upfront. That way the user can look through them if they are unsure about the precise search terms.

(A increase was requested by UX)