### PR TITLE
fix: make OAuth and saving to Wikidata work

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "express-session": "^1.17.1",
     "http-errors": "^1.8.0",
     "morgan": "^1.10.0",
+    "oauth": "^0.9.15",
     "passport": "^0.4.1",
     "passport-mediawiki-oauth": "^0.1.0",
     "prisma": "^2.19.0",

--- a/server/mw-api-client.js
+++ b/server/mw-api-client.js
@@ -1,8 +1,6 @@
-const axios = require("axios");
-const { response } = require("express");
-const url = require("url");
+const URL = require("url");
 const createError = require( "http-errors" );
-
+const OAuth = require("oauth");
 
 function validatePayload( payload ){
     if( payload.warnings || payload.errors ){
@@ -12,9 +10,51 @@ function validatePayload( payload ){
     return payload;
 }
 
+function signedRequest( url, session, params, options ) {
+    var oauth = new OAuth.OAuth(
+        // URL to request a token
+        'https://www.wikidata.org/index.php?title=Special:OAuth/initiate',
+        // URL to get access token
+        'https://www.wikidata.org/index.php??title=Special:OAuth/token',
+        session.consumer_key,
+        session.consumer_secret,
+        '1.0',
+        null,
+        'HMAC-SHA1'
+    );
+
+    return new Promise( function ( resolve, reject ) {
+        var handler = function ( err, data ) {
+            if ( err ) {
+                reject( JSON.stringify( err ) );
+            } else {
+                resolve( JSON.parse( data ) );
+            }
+        };
+
+        if ( options && options.method === 'POST' ) {
+            oauth.post(
+                url,
+                session.token,
+                session.token_secret,
+                params,
+                'application/json',
+                handler
+            );
+        } else {
+            url += '?' + new URL.URLSearchParams( params );
+            oauth.get(
+                url,
+                session.token,
+                session.token_secret,
+                handler );
+        }
+    } );
+}
+
 module.exports = class MWApiClient {
 
-    constructor( endpoint, params){
+    constructor( endpoint, params = {}, oauth = null ){
         if ( !endpoint ) {
             throw new Error('Cannot create a MediaWiki API client: missing endpoint paramater');
         }
@@ -26,45 +66,59 @@ module.exports = class MWApiClient {
             formatversion: 2,
             ...params
         };
-        
-        this.httpClient = axios.create({
-            baseURL: this.endpoint,
-            params: this.defaultParams
-        });
+
+        this.token = oauth ? {
+            key: oauth.token,
+            secret: oauth.token_secret
+        } : null;
     }
 
     async get( action, params, config ){
-        // Error handling is delegated to the caller. 
-        // This function will raise all exceptions that axios may raise. 
-        // See: https://www.npmjs.com/package/axios#handling-errors
-        const response = await this.httpClient.get('', {
-            params: {
-                action,
-                ...params
-            },
-            ...config
-        });
+        const payload = {
+            action,
+            ...this.defaultParams,
+            ...params
+        };
 
-        return validatePayload( response.data );
+        const data = await signedRequest(
+            this.endpoint,
+            {
+                consumer_key: process.env.OAUTH_KEY,
+                consumer_secret: process.env.OAUTH_SECRET,
+                token: this.token.key,
+                token_secret: this.token.secret,
+            },
+            payload,
+        );
+
+        return validatePayload( data );
     }
 
     async post( action, params, config ){
-        const body = new url.URLSearchParams({
+        const payload = {
             action,
+            ...this.defaultParams,
             ...params
-        });
-        
-        // Error handling is delegated to the caller. 
-        // This function will raise all exceptions that axios may raise. 
-        // See: https://www.npmjs.com/package/axios#handling-errors
-        const response = await this.httpClient.post('', body.toString(), config);
+        };
 
-        return validatePayload( response.data );
+        const data = await signedRequest(
+            this.endpoint,
+            {
+                consumer_key: process.env.OAUTH_KEY,
+                consumer_secret: process.env.OAUTH_SECRET,
+                token: this.token.key,
+                token_secret: this.token.secret,
+            },
+            payload,
+            { method: 'POST' },
+        );
+
+        return validatePayload( data );
     }
 
     async tokens( type = "csrf" ){
-        // Error handling is delegated to the caller. 
-        // This function will raise all exceptions that axios may raise. 
+        // Error handling is delegated to the caller.
+        // This function will raise all exceptions that axios may raise.
         // See: https://www.npmjs.com/package/axios#handling-errors
         const data = await this.get("query", {
             meta: "tokens",

--- a/server/routes.js
+++ b/server/routes.js
@@ -109,7 +109,8 @@ router.post( '/entity-connection', async ( req, res, next ) => {
 	// TODO: Clean this up by moving to service container and middleware
 	const statements = new StatementsRepository( new MWApiClient(
 		process.env.MW_API_URL,
-		{ assertuser: user.displayName }
+		{ assertuser: user.displayName },
+		user.oauth
 	) );
 	const entityConnections = new EntityConnectionRepository( statements );
 	const connectingPID = process.env.ITEM_CONNECTION_PID;


### PR DESCRIPTION
This replicates the basic flow of the oauth-fetch-json library by
jdlrobson. However, we cannot use that library directly as we need
Wikidata as the endpoint, not meta wiki.

Co-authored-by: Michael Große<michael.grosse@wikimedia.de>