### PR TITLE
Improve docs for backend development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,8 @@
 # Prisma supports the native connection string format for PostgreSQL, MySQL and SQLite.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-DATABASE_URL="mysql://someuser:somepassword@host.of.database/database_name"
+# DATABASE_URL="mysql://someuser:somepassword@host.of.database/database_name"
+DATABASE_URL="mysql://root:toor@localhost:3306/connecting-senses"
 
 # OAuth app credentials, for authentication with MediaWiki OAuth v1.0a
 OAUTH_KEY="0123456789abcdef"

--- a/README.md
+++ b/README.md
@@ -14,10 +14,23 @@ You may decide between connecting the item to this sense in Wikidata, skipping t
 
 Note: This tool uses Node 10 and npm 6.14.
 
-- create a local `.env` file (see `.env.example` for reference)
 - In order to start your local development environment, first run `npm i` to install dependencies.
+
+## frontend development
+
 - For the frontend environment run:
-    `npm run serve`
+  `npm run serve` and open the browser to http://localhost:8080/
+
+This will mock all requests to the local backend in the browser.
+The configuration for the mock editing and mock data can be found in `src/mocks/`.
+
+## server development
+
+- create a local `.env` file (see `.env.example` for reference)
+- you can spin up a development database with `docker-compose up`
+  - this will make a mariaDB instance available on port 3306
+  - the connection string in `.env.example` is already setup for this db
+  - also adminer can be used at http://localhost:3000
 - For backend development run:
     `npx nodemon --inspect server.js`
-Per default, the frontend development server will be running locally at `http://localhost:8080/ `, and the backend development server will run at port `5000`.
+  - the backend development server will run at http://localhost:5000.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.1'
+
+services:
+
+  db:
+    image: mariadb
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: toor
+    ports:
+      - 3306:3306
+
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 3000:8080


### PR DESCRIPTION
This expands the documentation, particularly the part about developing for the server.

Further improvements could be:
* how to deal with oauth during local development?
	* creating [owner-only credentials](https://www.mediawiki.org/wiki/OAuth/Owner-only_consumers) or is there a better way?
* a bit more about Prisma: `npx prisma studio`, `npx prisma migrate dev`, ...